### PR TITLE
Update SurrealDB to v2.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tera = "1"
 tower-http = { version = "0.5", features = ["fs"] }
+surrealdb = { version = "2.3.3", features = ["kv-mem", "protocol-ws"] }

--- a/src/handlers/index_handler.rs
+++ b/src/handlers/index_handler.rs
@@ -6,7 +6,9 @@ use axum::{
 };
 use serde::Serialize; // Needed for IndexPageData
 use std::sync::Arc;
-use tera::{Context, Tera};
+use tera::Context;
+
+use crate::AppState;
 
 // Temporary location for IndexPageData
 #[derive(Serialize)]
@@ -17,7 +19,8 @@ pub struct IndexPageData<'a> { // Made pub
     pub show_extra_info: bool,
 }
 
-pub async fn serve_index_page_handler( State(tera): State<Arc<Tera>>) -> impl IntoResponse {
+pub async fn serve_index_page_handler(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {
+    let tera = &app_state.templates;
     let mut context = Context::new();
     let page_data = IndexPageData {
         title: "Auteur.Engineer (from index_handler)",

--- a/src/handlers/mario_index_handler.rs
+++ b/src/handlers/mario_index_handler.rs
@@ -6,7 +6,9 @@ use axum::{
 };
 use serde::Serialize; // Needed for IndexPageData
 use std::sync::Arc;
-use tera::{Context, Tera};
+use tera::Context;
+
+use crate::AppState;
 
 // Temporary location for IndexPageData
 #[derive(Serialize)]
@@ -17,7 +19,8 @@ struct IndexPageData<'a> {
     pub show_extra_info: bool,
 }
 
-pub async fn serve_index_page_handler( State(tera): State<Arc<Tera>>) -> impl IntoResponse {
+pub async fn serve_index_page_handler(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {
+    let tera = &app_state.templates;
     let mut context = Context::new();
     let page_data = IndexPageData {
         title: "Mario Page",

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod api_handlers;
 pub(crate) mod index_handler;
 pub(crate) mod mario_index_handler;
+pub(crate) mod post_handlers;

--- a/src/handlers/post_handlers.rs
+++ b/src/handlers/post_handlers.rs
@@ -1,0 +1,62 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use surrealdb::sql::Thing;
+use std::sync::Arc;
+
+use crate::AppState;
+
+#[derive(Serialize, Deserialize)]
+pub struct Post {
+    pub id: Option<Thing>,
+    pub title: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreatePost {
+    pub title: String,
+}
+
+pub async fn create_post_handler(
+    State(app_state): State<Arc<AppState>>,
+    Json(payload): Json<CreatePost>,
+) -> impl IntoResponse {
+    let db = &app_state.db;
+    let result: Result<Vec<Post>, _> = db
+        .insert("posts")
+        .content(payload)
+        .await;
+
+    match result {
+        Ok(mut posts) => {
+            let post = posts.pop().unwrap();
+            (StatusCode::CREATED, Json(post)).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn get_posts_handler(
+    State(app_state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let db = &app_state.db;
+    let result: Result<Vec<Post>, _> = db.select("posts").await;
+
+    match result {
+        Ok(posts) => Json(posts).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,26 @@ mod handlers;
 
 use axum::{
     response::IntoResponse,
-    routing::get,
+    routing::{get, post},
     Router,
 };
 
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tera::{Context, Tera};
+use surrealdb::{
+    engine::remote::ws::Client as WsClient,
+    opt::auth::Root,
+    Surreal,
+};
 use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
 
+
+pub struct AppState {
+    pub templates: Arc<Tera>,
+    pub db: Arc<Surreal<WsClient>>,
+}
 
 
 
@@ -26,14 +36,37 @@ async fn main() {
     };
     // Wrap the Tera instance in an Arc to allow shared ownership across threads
     let shared_tera = Arc::new(tera_instance);
+
+    let db = Surreal::connect::<WsClient>("ws://localhost:8000")
+        .await
+        .unwrap();
+    db.signin(Root {
+        username: "root",
+        password: "root",
+    })
+    .await
+    .unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    let shared_db = Arc::new(db);
+
+    let app_state = Arc::new(AppState {
+        templates: shared_tera.clone(),
+        db: shared_db,
+    });
+
     let static_files_service = ServeDir::new("public")
         .append_index_html_on_directories(false);
     let app = Router::new()
         .route("/", get(handlers::index_handler::serve_index_page_handler))
         .route("/mario", get(handlers::mario_index_handler::serve_index_page_handler))
         .route("/api/hello", get(handlers::api_handlers::hello_json_api_handler))
+        .route(
+            "/api/posts",
+            post(handlers::post_handlers::create_post_handler)
+                .get(handlers::post_handlers::get_posts_handler),
+        )
         .nest_service("/public", static_files_service)
-        .with_state(shared_tera);
+        .with_state(app_state);
 
     // TODO(harwood) refactor this to make work when hosted in cloud
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));


### PR DESCRIPTION
## Summary
- update SurrealDB crate to `2.3.3`
- switch to `protocol-ws` feature and new `WsClient` API
- adjust app initialization for new client
- store Surreal `Thing` IDs for posts
- use `insert` for Surreal create action

## Testing
- `cargo check` *(fails: could not fetch crates)*