### PR TITLE
Add plat_schema workspace with derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plat_schema"
+version = "0.1.0"
+dependencies = [
+ "plat_schema_macros",
+ "serde",
+]
+
+[[package]]
+name = "plat_schema_macros"
+version = "0.1.0"
+dependencies = [
+ "plat_schema",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["website"]
+members = [ "plat_schema", "plat_schema_macros","website"]
 default-members = ["website"]

--- a/plat_schema/Cargo.toml
+++ b/plat_schema/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "plat_schema"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+plat_schema_macros = { path = "../plat_schema_macros" }

--- a/plat_schema/README.md
+++ b/plat_schema/README.md
@@ -1,0 +1,17 @@
+# plat_schema
+
+Provides the `Schema` trait and the `PlatSchema` derive macro.
+
+```rust
+use plat_schema::Schema;
+use plat_schema_macros::PlatSchema;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, PlatSchema)]
+struct Post {
+    id: Option<u32>,
+    title: String,
+}
+
+assert_eq!(Post::name(), "Post");
+```

--- a/plat_schema/src/lib.rs
+++ b/plat_schema/src/lib.rs
@@ -1,0 +1,3 @@
+pub trait Schema {
+    fn name() -> &'static str;
+}

--- a/plat_schema/tests/derive.rs
+++ b/plat_schema/tests/derive.rs
@@ -1,0 +1,14 @@
+use plat_schema::Schema;
+use plat_schema_macros::PlatSchema;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, PlatSchema)]
+struct Post {
+    id: Option<u32>,
+    title: String,
+}
+
+#[test]
+fn name_returns_struct_name() {
+    assert_eq!(Post::name(), "Post");
+}

--- a/plat_schema_macros/Cargo.toml
+++ b/plat_schema_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "plat_schema_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = { version = "2", features = ["full"] }
+proc-macro2 = "1"
+plat_schema = { path = "../plat_schema" }

--- a/plat_schema_macros/src/lib.rs
+++ b/plat_schema_macros/src/lib.rs
@@ -1,0 +1,18 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(PlatSchema)]
+pub fn plat_schema_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = ast.ident;
+    let name_str = ident.to_string();
+    let expanded = quote! {
+        impl plat_schema::Schema for #ident {
+            fn name() -> &'static str {
+                #name_str
+            }
+        }
+    };
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
## Summary
- add `plat_schema` library with `Schema` trait
- add `plat_schema_macros` proc-macro crate with `PlatSchema` derive
- update workspace to include both crates
- document usage and provide tests

## Testing
- `cargo test -p plat_schema`
- `cargo check -p plat_schema_macros`
- `cargo check -p website`
