### PR TITLE
Add websocket live updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -351,8 +352,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3603,7 +3606,7 @@ dependencies = [
  "surrealdb-core",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tokio-util",
  "tracing",
  "trice",
@@ -4010,8 +4013,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.23.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -4165,6 +4180,24 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -4541,6 +4574,7 @@ name = "website"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures",
  "plat_schema",
  "plat_schema_macros",
  "serde",

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tera = "1"
 tower-http = { version = "0.5", features = ["fs"] }
 surrealdb = { version = "2.3.3", features = ["kv-mem", "protocol-ws"] }
+futures = "0.3"
 plat_schema = { path = "../plat_schema" }
 plat_schema_macros = { path = "../plat_schema_macros" }

--- a/website/src/handlers/mod.rs
+++ b/website/src/handlers/mod.rs
@@ -2,3 +2,4 @@ pub mod api_handlers;
 pub(crate) mod index_handler;
 pub(crate) mod mario_index_handler;
 pub(crate) mod post_handlers;
+pub(crate) mod rpc_handlers;

--- a/website/src/handlers/rpc_handlers.rs
+++ b/website/src/handlers/rpc_handlers.rs
@@ -2,12 +2,13 @@ use axum::{
     extract::{ws::{Message, WebSocket}, State, WebSocketUpgrade},
     response::IntoResponse,
 };
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use std::sync::Arc;
 use surrealdb::Surreal;
 use surrealdb::engine::remote::ws::Client as WsClient;
 
 use crate::AppState;
+use crate::handlers::post_handlers::Post;
 
 pub async fn rpc_handler(
     State(app_state): State<Arc<AppState>>,
@@ -19,7 +20,7 @@ pub async fn rpc_handler(
 
 async fn handle_ws(mut socket: WebSocket, db: Arc<Surreal<WsClient>>) {
     let mut stream = db
-        .select("posts")
+        .select::<Vec<Post>>("posts")
         .live()
         .await
         .unwrap();

--- a/website/src/handlers/rpc_handlers.rs
+++ b/website/src/handlers/rpc_handlers.rs
@@ -1,0 +1,33 @@
+use axum::{
+    extract::{ws::{Message, WebSocket}, State, WebSocketUpgrade},
+    response::IntoResponse,
+};
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+use surrealdb::Surreal;
+use surrealdb::engine::remote::ws::Client as WsClient;
+
+use crate::AppState;
+
+pub async fn rpc_handler(
+    State(app_state): State<Arc<AppState>>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    let db = app_state.db.clone();
+    ws.on_upgrade(move |socket| handle_ws(socket, db))
+}
+
+async fn handle_ws(mut socket: WebSocket, db: Arc<Surreal<WsClient>>) {
+    let mut stream = db
+        .select("posts")
+        .live()
+        .await
+        .unwrap();
+
+    while let Some(Ok(notification)) = stream.next().await {
+        let txt = serde_json::to_string(&(notification.action, notification.data)).unwrap();
+        if socket.send(Message::Text(txt)).await.is_err() {
+            break;
+        }
+    }
+}

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -1,13 +1,12 @@
 mod handlers;
 
 use axum::{
-    routing::{get},
+    routing::{get, post},
     Router,
 };
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-use axum::routing::post;
 use tera::Tera;
 use surrealdb::engine::remote::ws::{Client as WsClient, Ws};
 use surrealdb::{opt::auth::Root, Surreal};
@@ -103,6 +102,7 @@ async fn main() {
             post(handlers::post_handlers::create_post_handler)
                 .get(handlers::post_handlers::get_posts_handler),
         )
+        .route("/rpc", get(handlers::rpc_handlers::rpc_handler))
         .fallback_service(static_files_service)
         .with_state(app_state);
     println!("Axum router configured.");

--- a/website/templates/admin/posts/index.html
+++ b/website/templates/admin/posts/index.html
@@ -61,5 +61,17 @@
                 }
             });
     </script>
+    <script>
+    const ul = document.querySelector('ul');
+    const ws = new WebSocket(`ws://${location.host}/rpc`);
+    ws.onmessage = evt => {
+        const [action, post] = JSON.parse(evt.data);
+        if (action === 'CREATE') {
+            const li = document.createElement('li');
+            li.textContent = post.title.label;
+            ul.appendChild(li);
+        }
+    };
+    </script>
 </body>
 </html>

--- a/website/templates/admin/posts/index.html
+++ b/website/templates/admin/posts/index.html
@@ -66,7 +66,8 @@
     const ws = new WebSocket(`ws://${location.host}/rpc`);
     ws.onmessage = evt => {
         const [action, post] = JSON.parse(evt.data);
-        if (action === 'CREATE') {
+
+        if (action === 'Create') {
             const li = document.createElement('li');
             li.textContent = post.title.label;
             ul.appendChild(li);


### PR DESCRIPTION
## Summary
- add websocket route and rpc handler
- push live updates to clients from SurrealDB
- update main router and handler modules
- enhance posts index template with live updates
- enable Axum websocket feature and add futures crate

## Testing
- `cargo check --package website` *(fails: could not download tokio-tungstenite 0.24.0)*