### PR TITLE
Implement basic block editor

### DIFF
--- a/website/src/block_schemas.rs
+++ b/website/src/block_schemas.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct FieldSchema {
+    pub name: &'static str,
+    pub label: &'static str,
+    pub form_type: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct BlockSchema {
+    pub block_type: &'static str,
+    pub fields: &'static [FieldSchema],
+}
+
+pub const HEADER_SCHEMA: BlockSchema = BlockSchema {
+    block_type: "Header",
+    fields: &[
+        FieldSchema {
+            name: "content",
+            label: "Content",
+            form_type: "InputArea",
+        },
+    ],
+};
+
+pub const FOOTER_SCHEMA: BlockSchema = BlockSchema {
+    block_type: "Footer",
+    fields: &[
+        FieldSchema {
+            name: "copyright",
+            label: "Copyright",
+            form_type: "InputText",
+        },
+    ],
+};
+
+pub const ALL_BLOCK_SCHEMAS: &[BlockSchema] = &[HEADER_SCHEMA, FOOTER_SCHEMA];
+
+pub fn get_all_block_schemas() -> &'static [BlockSchema] {
+    ALL_BLOCK_SCHEMAS
+}

--- a/website/src/handlers/post_handlers.rs
+++ b/website/src/handlers/post_handlers.rs
@@ -120,6 +120,7 @@ pub async fn serve_admin_page_id_handler(State(app_state): State<Arc<AppState>>,
     
     let mut context = Context::new();
     context.insert("post", &posts_data);
+    context.insert("schemas_json", &app_state.block_schemas_json);
     println!("{:?}", posts_data);
     match tera.render("admin/posts/[id].html", &context) {
         Ok(html) => Html(html).into_response(),
@@ -171,6 +172,58 @@ pub async fn get_posts_handler(State(app_state): State<Arc<AppState>>) -> impl I
 
     match result {
         Ok(posts) => Json(posts).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "block_type", content = "block_data")]
+pub enum UpsertBlockPayload {
+    Header(Header),
+    Footer(Footer),
+}
+
+pub async fn update_post_handler(
+    State(app_state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(payload): Json<UpsertBlockPayload>,
+) -> impl IntoResponse {
+    let db = &app_state.db;
+
+    let mut post: Option<Post> = match db.select(("posts", id.clone())).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
+    let Some(mut post) = post else {
+        return (StatusCode::NOT_FOUND, "post not found").into_response();
+    };
+
+    let block = match payload {
+        UpsertBlockPayload::Header(h) => Block::Header(h),
+        UpsertBlockPayload::Footer(f) => Block::Footer(f),
+    };
+    post.blocks.push(block);
+
+    let result: Result<Option<Post>, _> = db
+        .update(("posts", id))
+        .merge(json!({"blocks": post.blocks}))
+        .await;
+
+    match result {
+        Ok(Some(updated)) => Json(updated).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "post not found").into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": e.to_string()})),

--- a/website/templates/admin/posts/[id].html
+++ b/website/templates/admin/posts/[id].html
@@ -21,6 +21,26 @@
 
         main {
             height: 100vh;
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+            gap: var(--space-4);
+            padding: var(--space-4);
+        }
+
+        .existing-blocks {
+            overflow-y: auto;
+            padding-right: var(--space-2);
+        }
+
+        .preview {
+            border-top: 1px solid var(--secondary-color);
+            margin-top: var(--space-2);
+        }
+
+        @media (max-width: 600px) {
+            main {
+                grid-template-columns: 1fr;
+            }
         }
 
         .navigation-bar {
@@ -40,13 +60,16 @@
         {{ forms::theme_toggle_button(text="theme-toggle", class="text") }}
     </nav>
     <main>
-        <div class="block-add">
-            <select>
-                <option>header</option>
-                <option>footer</option>
-            </select>
-            <button>add block</button>
+        <div class="existing-blocks">
+            {% for block in post.blocks %}
+                <pre>{{ block | escape }}</pre>
+            {% else %}
+                <p>No blocks</p>
+            {% endfor %}
         </div>
+        <block-adder
+            data-post-id="{{ post.id.id.String }}"
+            data-schemas='{{ schemas_json }}'></block-adder>
     </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define constant block schema info
- expose schemas JSON via `AppState` and render it in post admin page
- add PUT `/api/posts/:id` route with handler to append blocks
- create `block-adder` web component for client-side editing
- layout admin post page with two columns and preview area

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_683a34fdf130832cbd6465433f644a29