### PR TITLE
Implement post update API

### DIFF
--- a/website/src/handlers/post_handlers.rs
+++ b/website/src/handlers/post_handlers.rs
@@ -176,3 +176,30 @@ pub async fn get_posts_handler(State(app_state): State<Arc<AppState>>) -> impl I
             .into_response(),
     }
 }
+
+pub async fn update_post_handler(
+    State(app_state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(payload): Json<Post>,
+) -> impl IntoResponse {
+    let db = &app_state.db;
+
+    let result: Result<Option<Post>, _> = db
+        .update(("posts", id))
+        .content(payload)
+        .await;
+
+    match result {
+        Ok(Some(post)) => (StatusCode::OK, Json(post)).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Post not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -103,6 +103,10 @@ async fn main() {
             post(handlers::post_handlers::create_post_handler)
                 .get(handlers::post_handlers::get_posts_handler),
         )
+        .route(
+            "/api/posts/:id",
+            post(handlers::post_handlers::update_post_handler),
+        )
         .route("/counter", get(handlers::counter_handler::page_handler))
         .route("/api/counter/:id", post(handlers::counter_handler::create_handler))
         .route("/rpc", get(handlers::rpc_handlers::rpc_handler))


### PR DESCRIPTION
## Summary
- add an API handler for updating posts
- register new route for post updates

## Testing
- `cargo test --manifest-path website/Cargo.toml --no-run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407e0383dc832c83532a863ff5f0e3