### PR TITLE
Improve admin post edit form

### DIFF
--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -20,6 +20,9 @@
     --background-color: #fff;
     --primary-color: #007bff;
     --secondary-color: #6c757d;
+    --input-bg: var(--background-color);
+    --input-text: var(--text-color);
+    --input-border: #ccc;
     --font-display: 'monument_extendedblack', sans-serif;
     --font-serif: 'pp_writerregular', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
     --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
@@ -253,3 +256,41 @@ p {
 
 /* 5) light vs dark icons – JS will add `.show` */
 .icon-select .icon.show { display: block; }
+/* Form controls */
+input[type="text"], textarea, select {
+    width: 100%;
+    padding: var(--space-2);
+    background: var(--input-bg, var(--background-color));
+    color: var(--input-text, var(--text-color));
+    border: 1px solid var(--input-border, #ccc);
+    border-radius: 4px;
+    font-family: var(--font-sans);
+    transition: border-color 0.2s, box-shadow 0.2s;
+    outline: none;
+}
+
+input[type="text"]:hover,
+textarea:hover,
+select:hover {
+    border-color: var(--text-color);
+}
+
+input[type="text"]:focus,
+textarea:focus,
+select:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px var(--primary-color);
+}
+
+input[type="text"]:disabled,
+textarea:disabled,
+select:disabled {
+    background: var(--secondary-color);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+input[type="text"]::placeholder,
+textarea::placeholder {
+    color: var(--secondary-color);
+}

--- a/website/templates/admin/posts/[id].html
+++ b/website/templates/admin/posts/[id].html
@@ -1,4 +1,5 @@
-{% import "macros.html" as forms %}
+{% import "macros.html" as macros %}
+{% import "macros/forms.html" as forms %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -15,8 +16,9 @@
             margin: 0;
             padding: 0;
             height: 100%;
-            font-family: var(--font-display);
+            font-family: var(--font-sans);
             background: var(--background-color);
+            color: var(--text-color);
         }
 
         main {
@@ -28,27 +30,55 @@
             border-bottom: 1px solid var(--secondary-color);
             padding: var(--space-2) var(--space-4);
             text-transform: uppercase;
-            a {
-                color: var(--text-color);
-                text-decoration: none;
-            }
         }
+
+        .navigation-bar a {
+            color: var(--text-color);
+            text-decoration: none;
+        }
+
         .preview {
-            width: 66.6%;
-            padding: var(--space-4);
-            background: #222;
+            width: var(--size-2_3);
+            padding: var(--space-6);
+            background: var(--background-color);
+            color: var(--text-color);
         }
+
         .form {
-            width: 33.3%;
-            padding: var(--space-4);
-            background: #666;
+            width: var(--size-1_3);
+            padding: var(--space-6);
+            background: var(--background-color);
+            border-left: 1px solid var(--secondary-color);
+            overflow-y: auto;
+        }
+
+        .form-group {
+            margin-bottom: var(--space-4);
+            display: flex;
+            flex-direction: column;
+            gap: var(--space-2);
+        }
+
+        button {
+            padding: var(--space-2) var(--space-4);
+            border-radius: 4px;
+            background: var(--text-color);
+            color: var(--background-color);
+            border: 1px solid var(--text-color);
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        button:hover {
+            background: var(--background-color);
+            color: var(--text-color);
         }
     </style>
 </head>
 <body>
     <nav class="navigation-bar">
         <a href="/admin/posts/">Auteur</a>
-        {{ forms::theme_toggle_button(text="theme-toggle", class="text") }}
+        {{ macros::theme_toggle_button(text="theme-toggle", class="text") }}
     </nav>
     <main>
         <div class="preview">
@@ -59,14 +89,8 @@
         </div>
         <div class="form">
             <form id="update-post-form">
-                <div class="form-group">
-                    <label for="post-id">ID</label>
-                    <input type="text" id="post-id" value="{{ post.id.id.String }}" disabled />
-                </div>
-                <div class="form-group">
-                    <label for="title">Title</label>
-                    <input type="text" id="title" name="title" value="{{ post.title.label }}" />
-                </div>
+                {{ forms::input(name="post-id", label="ID", value=post.id.id.String, attrs="disabled") }}
+                {{ forms::input(name="title", label="Title", value=post.title.label) }}
 
                 <div id="blocks-container">
                 {# Iterate over the blocks provided by PAGE_SCHEMA #}

--- a/website/templates/macros/forms.html
+++ b/website/templates/macros/forms.html
@@ -1,0 +1,13 @@
+{% macro input(name, label, type="text", value="", placeholder="", attrs="") %}
+<div class="form-group">
+    <label for="{{ name }}">{{ label }}</label>
+    <input type="{{ type }}" name="{{ name }}" id="{{ name }}" value="{{ value }}" placeholder="{{ placeholder }}" {{ attrs | safe }} />
+</div>
+{% endmacro %}
+
+{% macro textarea(name, label, value="", placeholder="", rows="5", attrs="") %}
+<div class="form-group">
+    <label for="{{ name }}">{{ label }}</label>
+    <textarea name="{{ name }}" id="{{ name }}" placeholder="{{ placeholder }}" rows="{{ rows }}" {{ attrs | safe }}>{{ value }}</textarea>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- create forms macros for reusable input/textarea helpers
- modernize admin post edit page with new macros and sleek styles
- add global form styling variables and rules

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6840cfc4d704832c87bae813476e6397