### PR TITLE
Refactor admin post editor

### DIFF
--- a/website/templates/admin/posts/[id].html
+++ b/website/templates/admin/posts/[id].html
@@ -81,8 +81,8 @@
         <a href="/admin/posts/">Auteur</a>
         {{ macros::theme_toggle_button(text="theme-toggle", class="text") }}
     </nav>
-    <main>
-        <div class="preview" id="preview">
+    <main is="art-post-page" art-uid="{{ post.id.id.String }}" art-page="{{ page_schema | json_encode | escape }}">
+        <div class="preview" data-preview>
             {% for block in page_schema %}
                 {% if block.Header is defined %}
                     {{ blocks::header(text=block.Header.content.label) }}
@@ -96,7 +96,7 @@
                 {{ forms::input(name="post-id", label="ID", value=post.id.id.String, attrs="disabled") }}
                 {{ forms::input(name="title", label="Title", value=post.title.label) }}
 
-                <div id="blocks-container">
+                <div data-blocks>
                 {# Iterate over the blocks provided by PAGE_SCHEMA #}
                 {% for block in page_schema %}
                     {% if block.Header is defined %}
@@ -115,7 +115,7 @@
 
                 <div class="form-group">
                     <label for="add-block-select">Add Block</label>
-                    <select id="add-block-select">
+                    <select id="add-block-select" is="art-block-type-select">
                         <option value="Header">Header</option>
                         <option value="Footer">Footer</option>
                     </select>
@@ -145,7 +145,6 @@
         </div>
     </template>
     <post-ws-listener art-uid="{{ post.id.id.String }}"></post-ws-listener>
-    <script id="page-data" type="application/json">{{ page_schema | json_encode | safe }}</script>
     <script type="module">
         import { signal, effect } from '/signal.js';
         const table = new Map();
@@ -156,6 +155,7 @@
             }
             return table.get(id);
         }
+        let blocks;
         class ArtBlockTypeSelect extends HTMLSelectElement {
             connectedCallback() {
                 this.signal = useStore('block-type', this.value);
@@ -173,7 +173,7 @@
                 this.addEventListener('submit', async e => {
                     e.preventDefault();
                     const payload = {
-                        title: { label: document.getElementById('title').value, hint: '', form_type: 'InputText' },
+                        title: { label: this.querySelector('#title').value, hint: '', form_type: 'InputText' },
                         blocks: blocks.value.map(b => {
                             if (b.type === 'Header') {
                                 return { Header: { content: { label: b.label, hint: '', form_type: 'InputArea' } } };
@@ -205,12 +205,12 @@
                 this.addEventListener('click', () => {
                     const type = blockTypeSignal.value;
                     const tplId = `${type.toLowerCase()}-form-template`;
-                    const tpl = document.getElementById(tplId);
+                    const tpl = this.form.querySelector('#' + tplId);
 
                     if (!tpl) return;
 
                     const clone = tpl.content.cloneNode(true);
-                    const el = this.form.querySelector('#blocks-container');
+                    const el = this.form.querySelector('[data-blocks]');
                     const index = blocks.value.length;
 
                     const input = clone.querySelector('[is="art-block-input"]');
@@ -226,31 +226,47 @@
             }
         }
         customElements.define('art-add-block-btn', ArtAddBlockBtn, { extends: 'button' });
-        const postId = "{{ post.id.id.String }}";
 
-        const blocksContainer = document.getElementById('blocks-container');
+        class ArtPostPage extends HTMLElement {
+            connectedCallback() {
+                const raw = this.getAttribute('art-page') || '[]';
+                let initial = [];
+                try {
+                    initial = JSON.parse(raw);
+                } catch (err) {
+                    console.error('Failed to parse page schema:', err);
+                }
 
+                this.preview = this.querySelector('[data-preview]');
+                this.blocksContainer = this.querySelector('[data-blocks]');
+                this.headerTpl = this.querySelector('#header-preview-template').content;
+                this.footerTpl = this.querySelector('#footer-preview-template').content;
 
-        const preview = document.getElementById('preview');
-        const headerTpl = document.getElementById('header-preview-template').content;
-        const footerTpl = document.getElementById('footer-preview-template').content;
-        let initial = [];
-        try {
-            const raw = document.getElementById('page-data')?.textContent;
-            if (raw) {
-                initial = JSON.parse(raw);
-            } else {
-                console.warn('No page-data element found or it has no content.');
+                blocks = useStore('blocks', initial.map(b => {
+                    if (b.Header) return { type: 'Header', label: b.Header.content.label };
+                    if (b.Footer) return { type: 'Footer', label: b.Footer.copyright.label };
+                }));
+
+                this.blocksContainer.querySelectorAll('.block-group').forEach((el, idx) => attachInput(el, idx));
+
+                effect(() => {
+                    this.preview.innerHTML = '';
+                    blocks.value.forEach(b => {
+                        let frag;
+                        if (b.type === 'Header') {
+                            frag = this.headerTpl.cloneNode(true);
+                            frag.querySelector('h2').textContent = b.label;
+                        } else if (b.type === 'Footer') {
+                            frag = this.footerTpl.cloneNode(true);
+                            frag.querySelector('p').textContent = `\u00A9 ${b.label}`;
+                        }
+                        if (frag) this.preview.appendChild(frag);
+                    });
+                });
             }
-        } catch (err) {
-            console.error('Failed to parse page-data JSON:', err);
-            initial = []; // fallback
         }
 
-        const blocks = signal(initial.map(b => {
-            if (b.Header) return { type: 'Header', label: b.Header.content.label };
-            if (b.Footer) return { type: 'Footer', label: b.Footer.copyright.label };
-        }));
+        customElements.define('art-post-page', ArtPostPage, { extends: 'main' });
 
         function attachInput(el, index) {
             const input = el.querySelector('textarea, input');
@@ -260,24 +276,6 @@
                 blocks.value = arr;
             });
         }
-
-        // attach listeners to existing groups
-        blocksContainer.querySelectorAll('.block-group').forEach((el, idx) => attachInput(el, idx));
-
-        effect(() => {
-            preview.innerHTML = '';
-            blocks.value.forEach(b => {
-                let frag;
-                if (b.type === 'Header') {
-                    frag = headerTpl.cloneNode(true);
-                    frag.querySelector('h2').textContent = b.label;
-                } else if (b.type === 'Footer') {
-                    frag = footerTpl.cloneNode(true);
-                    frag.querySelector('p').textContent = `\u00A9 ${b.label}`;
-                }
-                if (frag) preview.appendChild(frag);
-            });
-        });
         class PostWsListener extends HTMLElement {
             connectedCallback() {
                 const postId = this.getAttribute('art-uid');


### PR DESCRIPTION
## Summary
- convert admin post page to use web components for local state
- move post schema into main element attributes
- avoid global DOM queries in JS

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6840f6a1df14832c92dcabf741d0dbf4